### PR TITLE
Fix devcontainer to run midigen

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "codespaces": {
       "openFiles": [
         "README.md",
-        "cirklon_midi_generator.py"
+        "midigen.py"
       ]
     },
     "vscode": {
@@ -19,7 +19,7 @@
   },
   "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
   "postAttachCommand": {
-    "server": "streamlit run cirklon_midi_generator.py --server.enableCORS false --server.enableXsrfProtection false"
+    "server": "streamlit run midigen.py --server.enableCORS false --server.enableXsrfProtection false"
   },
   "portsAttributes": {
     "8501": {


### PR DESCRIPTION
## Summary
- update openFiles to load `midigen.py`
- change postAttachCommand to run `midigen.py`

## Testing
- `python3 -m py_compile midigen.py` *(fails: invalid character)*
- `streamlit run midigen.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a26d00d7c8328b84e1c44587bdc68