### PR TITLE
Fix duplicate page config

### DIFF
--- a/midigen.py
+++ b/midigen.py
@@ -901,7 +901,7 @@ def midi_preview_sf2(notes, sf2_path, tempo=120):
         st.error(f"Erro ao gerar preview de áudio: {e}")
 
 # -------- MAIN APP --------
-st.set_page_config(layout="wide")
+
 st.title("Sistema IA MIDI Cirklon - Completo e Integrado")
 
 # Model persistence


### PR DESCRIPTION
## Summary
- keep first `st.set_page_config` call
- remove duplicate call later in the file

## Testing
- `python3 -m py_compile midigen.py` *(fails: invalid character '▶')*

------
https://chatgpt.com/codex/tasks/task_e_684a26cd43808328912918174e830ecd