### PR TITLE
Add license and modular utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ venv/
 
 # Misc
 *.log
+cirklon_operation_manual_1.22 (1).pdf

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cirkopn MIDI Generator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ The application will open in your browser at `http://localhost:8501/`.
 * Validation tools to ensure notes fit a musical scale
 * Audio preview using a SoundFont file
 
+## Usage
+
+The sidebar of the application guides you through the workflow:
+
+1. **CKIEditor** – manage Cirklon instruments.
+2. **Importar MIDI/CKC/CKI** – load existing sequences.
+3. **Editar Piano Roll** – draw or edit notes.
+4. **Automação Avançada** – create multi‑CC envelopes.
+5. **Treinar IA/Gerar Música** – train the polyphonic model and generate ideas.
+6. **Manipular MIDI** – apply breakbeat and micro‑timing tools.
+7. **Exportar Cirklon/MIDI** – save results in CKC/CKI or standard MIDI.
+8. **Preview Audio** – audition using a SoundFont.
+
+## Documentation
+
+The full Cirklon manual can be downloaded from the [Sequentix website](https://sequentix.com).
+
 ## License
 
-This project is provided as-is for demonstration purposes.
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/midi_utils.py
+++ b/midi_utils.py
@@ -1,0 +1,217 @@
+import json
+import struct
+import mido
+import numpy as np
+from collections import defaultdict
+
+
+def midi_to_poly_dataset(midi_file):
+    import streamlit as st
+    try:
+        if hasattr(midi_file, "read"):
+            mid = mido.MidiFile(file=midi_file)
+        else:
+            mid = mido.MidiFile(midi_file)
+        all_notes_for_ai = []
+        for i, mtrack in enumerate(mid.tracks):
+            active_notes = {}
+            abs_tick = 0
+            for msg in mtrack:
+                abs_tick += msg.time
+                if msg.type == 'note_on' and msg.velocity > 0:
+                    active_notes[(msg.note, msg.channel)] = abs_tick
+                elif msg.type == 'note_off' or (msg.type == 'note_on' and msg.velocity == 0):
+                    if (msg.note, msg.channel) in active_notes:
+                        start_tick = active_notes.pop((msg.note, msg.channel))
+                        duration = abs_tick - start_tick
+                        if duration > 0:
+                            all_notes_for_ai.append([
+                                start_tick,
+                                msg.note,
+                                msg.velocity,
+                                duration,
+                                i
+                            ])
+            for (note, channel), start_tick in active_notes.items():
+                duration = abs_tick - start_tick
+                if duration > 0:
+                    all_notes_for_ai.append([start_tick, note, 64, duration, i])
+        all_notes_for_ai.sort(key=lambda x: x[0])
+        final_dataset = []
+        last_abs_tick = 0
+        for note_event in all_notes_for_ai:
+            abs_tick, note, velocity, duration, track_idx = note_event
+            delta_tick = abs_tick - last_abs_tick
+            final_dataset.append([delta_tick, note, velocity, duration, track_idx])
+            last_abs_tick = abs_tick
+        return np.array(final_dataset) if final_dataset else np.array([])
+    except (IOError, ValueError) as e:
+        st.error(f"Erro ao processar arquivo MIDI: {e}")
+        return np.array([])
+
+
+def notes_to_midi_file(notes, tempo=120):
+    mid = mido.MidiFile()
+    max_track_idx = 0
+    if notes:
+        for track_data in notes:
+            if track_data.size > 0:
+                max_track_idx = max(max_track_idx, int(track_data[:, 4].max()))
+    for _ in range(max_track_idx + 1):
+        mid.tracks.append(mido.MidiTrack())
+    for track_data in notes:
+        abs_tick = 0
+        track_idx = int(track_data[0][4]) if len(track_data) > 0 else 0
+        for note_event in track_data:
+            delta, note, velocity, duration, track = note_event
+            abs_tick += delta
+            mid.tracks[track].append(mido.Message('note_on', note=int(note), velocity=int(velocity), time=delta))
+            mid.tracks[track].append(mido.Message('note_off', note=int(note), velocity=0, time=int(duration)))
+    if mid.tracks:
+        mid.tracks[0].insert(0, mido.MetaMessage("set_tempo", tempo=mido.bpm2tempo(tempo)))
+    return mid
+
+
+def export_midi_file(notes, out_path, tempo=120):
+    import streamlit as st
+    try:
+        midi_file = notes_to_midi_file(notes, tempo=tempo)
+        midi_file.save(out_path)
+        return out_path
+    except (IOError, ValueError) as e:
+        st.error(f"Erro ao exportar MIDI: {e}")
+        return None
+
+
+def export_ckc(notes, out_path):
+    import streamlit as st
+    try:
+        with open(out_path, "wb") as f:
+            f.write(b'CKC0')
+            for t, track in enumerate(notes):
+                for n in track:
+                    if n[3] > 0:
+                        f.write(struct.pack('<I', int(n[0])))
+                        f.write(struct.pack('B', int(n[1])))
+                        f.write(struct.pack('B', int(n[2])))
+                        f.write(struct.pack('B', int(n[3])))
+                        f.write(struct.pack('B', t))
+        return out_path
+    except IOError as e:
+        st.error(f"Erro ao exportar CKC: {e}")
+        return None
+
+
+def export_cki(notes, out_path):
+    import streamlit as st
+    try:
+        with open(out_path, "w") as f:
+            f.write("CKI,1\n")
+            for t, track in enumerate(notes):
+                for n in track:
+                    if n[3] > 0:
+                        line = f"{int(n[0])},{int(n[1])},{int(n[2])},{int(n[3])},{t}\n"
+                        f.write(line)
+        return out_path
+    except IOError as e:
+        st.error(f"Erro ao exportar CKI: {e}")
+        return None
+
+
+def export_p3pattern_json(notes, out_path):
+    import streamlit as st
+    try:
+        p3 = []
+        for t, track in enumerate(notes):
+            for n in track:
+                if n[3] > 0:
+                    ev = {
+                        "step": int(n[0]),
+                        "note": int(n[1]),
+                        "velocity": int(n[2]),
+                        "length": int(n[3]),
+                        "track": t
+                    }
+                    p3.append(ev)
+        with open(out_path, "w") as f:
+            json.dump({"p3_pattern": p3}, f, indent=2)
+        return out_path
+    except IOError as e:
+        st.error(f"Erro ao exportar P3 Pattern JSON: {e}")
+        return None
+
+
+def export_auxrows(notes, out_path):
+    import streamlit as st
+    try:
+        aux = []
+        for t, track in enumerate(notes):
+            for n in track:
+                if n[3] > 0:
+                    aux.append({
+                        "tick": int(n[0]),
+                        "cc_num": 74,
+                        "cc_val": int(n[2]),
+                        "track": t
+                    })
+        with open(out_path, "w") as f:
+            json.dump({"aux_rows": aux}, f, indent=2)
+        return out_path
+    except IOError as e:
+        st.error(f"Erro ao exportar Aux Rows: {e}")
+        return None
+
+
+def import_ckc_bin(path):
+    import streamlit as st
+    try:
+        with open(path, "rb") as f:
+            header = f.read(4)
+            if header != b'CKC0':
+                st.error("Arquivo CKC inválido")
+                return []
+            data = f.read()
+        notes = []
+        for i in range(0, len(data), 9):
+            step = struct.unpack('<I', data[i:i+4])[0]
+            note, velocity, length, track = struct.unpack('BBBB', data[i+4:i+8])
+            notes.append([step, note, velocity, length, track])
+        tracks = defaultdict(list)
+        for n in notes:
+            tracks[n[4]].append(n)
+        return [np.array(tracks[k]) for k in sorted(tracks)]
+    except IOError as e:
+        st.error(f"Erro ao importar CKC: {e}")
+        return []
+
+
+def import_cki_txt(path):
+    import streamlit as st
+    try:
+        notes = []
+        with open(path) as f:
+            for line in f:
+                if line.startswith("CKI"): continue
+                vals = [int(x) for x in line.strip().split(",")]
+                if len(vals) == 5:
+                    notes.append(vals)
+                else:
+                    st.warning(f"Linha CKI com formato inesperado: {line.strip()}")
+        tracks = defaultdict(list)
+        for n in notes:
+            tracks[n[4]].append(n)
+        return [np.array(tracks[k]) for k in sorted(tracks)]
+    except (IOError, ValueError) as e:
+        st.error(f"Erro ao importar CKI: {e}")
+        return []
+
+
+def import_auxrows_json(path):
+    import streamlit as st
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data.get("aux_rows", [])
+    except (IOError, json.JSONDecodeError) as e:
+        st.error(f"Erro ao importar Aux Rows JSON: {e}")
+        return []

--- a/model.py
+++ b/model.py
@@ -1,0 +1,76 @@
+import torch
+from torch import nn
+import numpy as np
+
+class PolyTransformer(nn.Module):
+    def __init__(self, n_tracks=4, d_model=128, num_lstm_layers=2, dropout_rate=0.2):
+        super().__init__()
+        self.note_embed = nn.Embedding(128, d_model // 2)
+        self.track_embed = nn.Embedding(n_tracks, d_model // 4)
+        self.continuous_linear = nn.Linear(3, d_model // 4)
+        lstm_input_size = (d_model // 2) + (d_model // 4) + (d_model // 4)
+        self.lstm = nn.LSTM(lstm_input_size, d_model, num_layers=num_lstm_layers, batch_first=True)
+        self.dropout = nn.Dropout(dropout_rate)
+        self.output = nn.Linear(d_model, n_tracks * 5)
+
+    def forward(self, x):
+        note = self.note_embed(x[:, :, 1].long())
+        track = self.track_embed(x[:, :, 4].long())
+        continuous = self.continuous_linear(x[:, :, :3].float())
+        x = torch.cat([note, track, continuous], dim=-1)
+        out, _ = self.lstm(x)
+        out = self.dropout(out)
+        out = self.output(out)
+        return out
+
+
+def train_poly_model(dataset, params):
+    import streamlit as st
+    try:
+        n_tracks = params.get("n_tracks", 4)
+        model = PolyTransformer(n_tracks=n_tracks)
+        optimizer = torch.optim.Adam(model.parameters(), lr=params.get("lr", 0.001))
+        loss_fn = nn.MSELoss()
+        loader = torch.utils.data.DataLoader(dataset, batch_size=params.get("batch_size", 1), shuffle=True)
+        for epoch in range(params.get("epochs", 10)):
+            total_loss = 0
+            for batch in loader:
+                optimizer.zero_grad()
+                out = model(batch)
+                loss = loss_fn(out, batch)
+                loss.backward()
+                optimizer.step()
+                total_loss += loss
+            if (epoch + 1) % 10 == 0:
+                st.write(f"Epoch {epoch+1}/{params['epochs']}, Total Loss: {total_loss.item():.4f}")
+        torch.save(model.state_dict(), params["model_path"])
+        return model
+    except RuntimeError as e:
+        st.error(f"Erro ao treinar o modelo de IA: {e}")
+        return None
+
+
+def infer_poly_sequence(model, seq_len=512, n_tracks=4, prime_sequence=None, randomness_temp=1.0):
+    import streamlit as st
+    try:
+        model.eval()
+        if prime_sequence is None:
+            prime_sequence = torch.zeros((1, 1, 5), dtype=torch.float)
+        generated = [prime_sequence]
+        for _ in range(seq_len):
+            inp = torch.cat(generated, dim=1)
+            out = model(inp)
+            next_step = out[:, -1, :].view(1, n_tracks, 5)
+            generated.append(next_step)
+        seq = torch.cat(generated, dim=1).squeeze(0)
+        out_sequences_by_track = {i: [] for i in range(n_tracks)}
+        cumulative = torch.zeros(n_tracks)
+        for step in seq:
+            delta, note, vel, dur, track = step
+            track = int(track.item())
+            cumulative[track] += delta.item()
+            out_sequences_by_track[track].append([delta.item(), note.item(), vel.item(), dur.item(), track])
+        return [np.array(out_sequences_by_track[k]) for k in sorted(out_sequences_by_track.keys())]
+    except RuntimeError as e:
+        st.error(f"Erro ao inferir sequência com o modelo de IA: {e}")
+        return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-streamlit
-streamlit-drawable-canvas
-plotly
-pandas
-numpy
-mido
-midi2audio
-torch
+streamlit==1.33.0
+streamlit-drawable-canvas==0.9.3
+plotly==5.18.0
+pandas==1.5.3
+numpy==1.23.5
+mido==1.2.10
+midi2audio==0.1.1
+torch==2.1.0

--- a/tests/test_midi_utils.py
+++ b/tests/test_midi_utils.py
@@ -1,0 +1,19 @@
+import os
+import numpy as np
+from midigen import notes_to_midi_file, export_midi_file, midi_to_poly_dataset
+
+def test_notes_to_midi_file_roundtrip(tmp_path):
+    notes = [np.array([[0, 60, 100, 120, 0]], dtype=int)]
+    midi = notes_to_midi_file(notes, tempo=120)
+    path = tmp_path / "out.mid"
+    midi.save(path)
+    assert path.exists()
+    new_notes = midi_to_poly_dataset(str(path))
+    assert new_notes.size > 0
+
+
+def test_export_midi_file(tmp_path):
+    notes = [np.array([[0, 60, 100, 120, 0]], dtype=int)]
+    path = tmp_path / "out.mid"
+    export_midi_file(notes, str(path), tempo=120)
+    assert os.path.exists(path)

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,60 @@
+import streamlit as st
+
+def track_values_panel(instrument):
+    st.subheader("Track Values")
+    for tv in instrument["track_values"]:
+        with st.container():
+            st.markdown(f"**Slot {tv['slot']}**")
+            tv["label"] = st.text_input(
+                f"Label (Slot {tv['slot']})",
+                tv.get("label", ""),
+                key=f"label_{tv['slot']}"
+            )
+            tv_type = st.selectbox(
+                "Tipo",
+                ["MidiCC", "TrackControl", "Empty"],
+                index={"MidiCC": 0, "TrackControl": 1, "Empty": 2}[tv.get("type", "Empty")],
+                key=f"type_{tv['slot']}"
+            )
+            tv["type"] = tv_type
+            if tv_type == "MidiCC":
+                tv["cc"] = st.number_input("CC #", 0, 127, tv.get("cc", 0), key=f"cc_{tv['slot']}")
+            elif tv_type == "TrackControl":
+                tv["track_control"] = st.selectbox(
+                    "Track Control",
+                    ["pgm", "quant%", "note%", "noteC", "velo%", "veloC", "leng%", "tbase", "xpos", "octave", "knob1", "knob2"],
+                    index=["pgm", "quant%", "note%", "noteC", "velo%", "veloC", "leng%", "tbase", "xpos", "octave", "knob1", "knob2"].index(tv.get("track_control", "pgm")),
+                    key=f"tc_{tv['slot']}"
+                )
+
+
+def note_rows_panel(instrument):
+    st.subheader("Note Rows")
+    for nr in instrument["note_rows"]:
+        with st.container():
+            st.markdown(f"**Slot {nr['slot']}**")
+            nr["name"] = st.text_input(
+                f"Nome (Slot {nr['slot']})", nr.get("name", ""), key=f"nrname_{nr['slot']}"
+            )
+            nr["note"] = st.text_input(
+                "Nota (ex: C3, D#4)", nr.get("note", ""), key=f"nrnote_{nr['slot']}"
+            )
+            nr["velocity"] = st.number_input(
+                "Velocidade", 1, 127, nr.get("velocity", 100), key=f"nrvelo_{nr['slot']}"
+            )
+
+
+def ccs_panel(instrument):
+    st.subheader("CCs")
+    for cc in instrument["ccs"]:
+        with st.container():
+            st.markdown(f"**Slot {cc['slot']}**")
+            cc["label"] = st.text_input(
+                f"Label (Slot {cc['slot']})", cc.get("label", ""), key=f"cclabel_{cc['slot']}"
+            )
+            cc["cc"] = st.number_input(
+                "CC #", 0, 127, cc.get("cc", 0), key=f"ccnum_{cc['slot']}"
+            )
+            cc["default"] = st.number_input(
+                "Valor Padrão", 0, 127, cc.get("default", 0), key=f"ccdef_{cc['slot']}"
+            )


### PR DESCRIPTION
## Summary
- add MIT license and reference in README
- link to Cirklon manual instead of storing PDF
- pin dependency versions
- introduce helper modules and simple tests
- clean up broad exception handling and duplicate imports

## Testing
- `python3 -m py_compile midigen.py midi_utils.py model.py ui.py tests/test_midi_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684c788439cc83288d16899cf5fa123f